### PR TITLE
Add static `.random(in:)` method

### DIFF
--- a/Sources/Percentage/Percentage.swift
+++ b/Sources/Percentage/Percentage.swift
@@ -115,8 +115,8 @@ public struct Percentage: Hashable, Codable {
 	//=> Can be 10%, 11%, 12%, 19.98%, etc.
 	```
 	*/
-	static func random(in range: ClosedRange<Percentage>) -> Percentage {
-		Percentage(fraction: Double.random(in: range.lowerBound.fraction...range.upperBound.fraction))
+	public static func random(in range: ClosedRange<Self>) -> Self {
+		self.init(fraction: .random(in: range.lowerBound.fraction...range.upperBound.fraction))
 	}
 }
 

--- a/Sources/Percentage/Percentage.swift
+++ b/Sources/Percentage/Percentage.swift
@@ -107,17 +107,17 @@ public struct Percentage: Hashable, Codable {
 	*/
 	public func of(_ value: Double) -> Double { value * rawValue / 100 }
     
-    /**
-    Returns a random value within the specified range.
+	/**
+	Returns a random value within the given range.
 
-    ```
-    Percent.random(in: 10%...20%)
-    //=> can be 10%, 11%, 12%, 19.98%, etc.
-    ```
-     */
-    static func random(in range: ClosedRange<Percentage>) -> Percentage {
-        return Percentage(fraction: Double.random(in: range.lowerBound.fraction...range.upperBound.fraction))
-    }
+	```
+	Percent.random(in: 10%...20%)
+	//=> Can be 10%, 11%, 12%, 19.98%, etc.
+	```
+	*/
+	static func random(in range: ClosedRange<Percentage>) -> Percentage {
+		Percentage(fraction: Double.random(in: range.lowerBound.fraction...range.upperBound.fraction))
+	}
 }
 
 extension Percentage: RawRepresentable {

--- a/Sources/Percentage/Percentage.swift
+++ b/Sources/Percentage/Percentage.swift
@@ -106,6 +106,18 @@ public struct Percentage: Hashable, Codable {
 	```
 	*/
 	public func of(_ value: Double) -> Double { value * rawValue / 100 }
+    
+    /**
+    Returns a random value within the specified range.
+
+    ```
+    Percent.random(in: 10%...20%)
+    //=> can be 10%, 11%, 12%, 19.98%, etc.
+    ```
+     */
+    static func random(in range: ClosedRange<Percentage>) -> Percentage {
+        return Percentage(fraction: Double.random(in: range.lowerBound.fraction...range.upperBound.fraction))
+    }
 }
 
 extension Percentage: RawRepresentable {


### PR DESCRIPTION
I am using this in an app and I thougt it might be useful to have it in the standard package.

Similar to [Double.random(in:)](https://developer.apple.com/documentation/swift/double/2995409-random) (which it uses internally)

I would have added tests but I am not sure how to test something that is random by design 🤔