### PR TITLE
Make percentage of given value generic

### DIFF
--- a/Sources/Percentage/Percentage.swift
+++ b/Sources/Percentage/Percentage.swift
@@ -101,14 +101,40 @@ public struct Percentage: Hashable, Codable {
 	}
 
 	/**
-	Returns how much the percentage of the given value is.
+	Returns how much the percentage of the given integer value is.
 
 	```
 	50%.of(200)
 	//=> 100
 	```
 	*/
-	public func of(_ value: Double) -> Double { value * rawValue / 100 }
+	public func of<I: BinaryInteger>(_ value: I) -> I {
+		return I(value) * I(rawValue.rounded()) / I(100)
+	}
+
+	/**
+	Returns how much the percentage of the given integer value is exactly, represented as floating-point.
+
+	```
+	50%.of(201) as Double
+	//=> 100.5
+	```
+	*/
+	public func of<I: BinaryInteger, F: BinaryFloatingPoint>(_ value: I) -> F {
+		return F(value) * F(rawValue) / F(100)
+	}
+
+	/**
+	Returns how much the percentage of the given floating-point value is.
+
+	```
+	50%.of(250.5)
+	//=> 125.25
+	```
+	*/
+	public func of<F: BinaryFloatingPoint>(_ value: F) -> F {
+		return F(value) * F(rawValue) / F(100)
+	}
 }
 
 extension Percentage {

--- a/Tests/PercentageTests/PercentageTests.swift
+++ b/Tests/PercentageTests/PercentageTests.swift
@@ -32,6 +32,14 @@ final class PercentageTests: XCTestCase {
 		XCTAssertTrue(30% > 25%)
 	}
 
+	func testPercentageOf() {
+		XCTAssertEqual(50%.of(200), 100)
+		XCTAssertEqual(50%.of(201), 100)
+		XCTAssertEqual(50%.of(201) as Double, 100.5)
+		XCTAssertEqual(50%.of(250.5), 125.25)
+		XCTAssertEqual(25%.of(Float64(200)), Float64(50))
+	}
+
 	func testArithmetics() {
 		XCTAssertEqual(1% + 1%, 2%)
 		XCTAssertEqual(1% - 1%, 0%)


### PR DESCRIPTION
Prior to this change, calculating such percentage from values of types different than `Double` would require type casting boilerplate. Now it is possible to find percentage of any `BinaryInteger` or `BinaryFloatingPoint`, with result always matching the original input type. Having mixed input and output is also supported, meaning it is possible to obtain the percentage of `BinaryInteger` as `BinaryFloatingPoint` (although not vice-versa; using an explicit type casting seems more reasonable in such cases).